### PR TITLE
doc(readme): fix example in readme file, added dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ with Geometry() as geo:
     wedge_curve_loop = CurveLoop.from_coords(
         wedge_coords, 
         mesh_size = 0.05,
-        labels=["upper", "outlet", "lower/1", "lower/2", "inlet"],
+        curve_labels=["upper", "outlet", "lower/1", "lower/2", "inlet"],
         fields=[
            TransfiniteCurveField(node_counts=[150,200,100,50,200])
         ]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
     "pythreejs",
     "su2fmt @ git+https://github.com/Turbodesigner/su2fmt.git",
     "shapely",
-    "scipy"
+    "scipy",
+    "plotly",
+    "ipython_genutils",
    ]
 )


### PR DESCRIPTION
The example in the readme did not run out of the box due to changed kwarg of the from_coords function in the CurveLoop class. 

Also some dependencies where missing to run the example. 